### PR TITLE
SRE-447: 不要なログをコメントアウト

### DIFF
--- a/cachers/redis/redis.go
+++ b/cachers/redis/redis.go
@@ -115,9 +115,9 @@ func (lc *LoggingConn) FlushContext(ctx context.Context) error {
 
 // Log the command and connection age
 func calculateLifeTime(ctx context.Context, lc *LoggingConn, operation string) {
-	elapsedTime := time.Since(lc.CreatedAt)
-	LastUsedDuration := time.Since(lc.LastUsed)
-	log.Infof(ctx, "Operation: %s, Connection Id: %s, Connection createdAt: %s, Connection LastUsed: %s, LastUsedAfterDuration: %v, Existence Time: %v", operation, lc.Id, lc.CreatedAt.Format("2006-01-02 15:04:05.000000000"), lc.LastUsed.Format("2006-01-02 15:04:05.000000000"), LastUsedDuration, elapsedTime)
+	//elapsedTime := time.Since(lc.CreatedAt)
+	//LastUsedDuration := time.Since(lc.LastUsed)
+	//log.Infof(ctx, "Operation: %s, Connection Id: %s, Connection createdAt: %s, Connection LastUsed: %s, LastUsedAfterDuration: %v, Existence Time: %v", operation, lc.Id, lc.CreatedAt.Format("2006-01-02 15:04:05.000000000"), lc.LastUsed.Format("2006-01-02 15:04:05.000000000"), LastUsedDuration, elapsedTime)
 }
 
 func getStats(ctx context.Context, stats redis.PoolStats) {

--- a/cachers/redis/redis.go
+++ b/cachers/redis/redis.go
@@ -122,7 +122,7 @@ func calculateLifeTime(ctx context.Context, lc *LoggingConn, operation string) {
 
 func getStats(ctx context.Context, stats redis.PoolStats) {
 	// Log current connection pool stats (idle and active connections)
-	log.Infof(ctx, "Active connections: %d, Idle connections: %d", stats.ActiveCount, stats.IdleCount)
+	//log.Infof(ctx, "Active connections: %d, Idle connections: %d", stats.ActiveCount, stats.IdleCount)
 }
 
 func (b *backend) AddMulti(ctx context.Context, items []*nds.Item) (err error) {


### PR DESCRIPTION
Active connections: 5, Idle connections: 3 という不要なログが増えている